### PR TITLE
Make `itoa` an optional dependency under a new `faster` feature.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - run: cargo build
       - run: rake
       - run: cargo test
+      - run: cargo test --features faster
       - run: cargo bench
       - run: cargo fmt -- --check
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,10 @@ jobs:
       - run: rake
       - run: cargo test
       - run: cargo test --features faster
+        working-directory: markup
       - run: cargo bench
       - run: cargo bench --features faster
+        working-directory: markup
       - run: cargo fmt -- --check
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - run: cargo clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - run: cargo test
       - run: cargo test --features faster
       - run: cargo bench
+      - run: cargo bench --features faster
       - run: cargo fmt -- --check
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - run: cargo clippy

--- a/markup/Cargo.toml
+++ b/markup/Cargo.toml
@@ -12,9 +12,12 @@ readme = "README.md"
 keywords = ["template", "html", "pug", "jade", "haml"]
 categories = ["template-engine"]
 
+[features]
+faster = ["itoa"]
+
 [dependencies]
 markup-proc-macro = { path = "../markup-proc-macro", version = "0.9.1" }
-itoa = { version = "0.4", features = ["i128"] }
+itoa = { version = "0.4", features = ["i128"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/markup/src/lib.rs
+++ b/markup/src/lib.rs
@@ -79,7 +79,16 @@ macro_rules! display {
 
 display! {
     [bool char f32 f64] => |self_, w| write!(w, "{}", self_),
+}
+
+#[cfg(feature = "faster")]
+display! {
     [u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize] => |self_, w| itoa::fmt(w, *self_),
+}
+
+#[cfg(not(feature = "faster"))]
+display! {
+    [u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize] => |self_, w| write!(w, "{}", self_),
 }
 
 #[inline]

--- a/markup/src/lib.rs
+++ b/markup/src/lib.rs
@@ -79,16 +79,12 @@ macro_rules! display {
 
 display! {
     [bool char f32 f64] => |self_, w| write!(w, "{}", self_),
-}
-
-#[cfg(feature = "faster")]
-display! {
-    [u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize] => |self_, w| itoa::fmt(w, *self_),
-}
-
-#[cfg(not(feature = "faster"))]
-display! {
-    [u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize] => |self_, w| write!(w, "{}", self_),
+    [u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize] => |self_, w| {
+        #[cfg(feature = "faster")]
+        { itoa::fmt(w, *self_) }
+        #[cfg(not(feature = "faster"))]
+        { write!(w, "{}", self_) }
+    },
 }
 
 #[inline]


### PR DESCRIPTION
This removes the only non-proc-macro dependency from the crate. If one cares about integer writing optimizations, they can enable this feature.