### PR TITLE
Add Raw attributes with () syntax

### DIFF
--- a/markup-proc-macro/src/ast.rs
+++ b/markup-proc-macro/src/ast.rs
@@ -29,7 +29,7 @@ pub struct Element {
     pub name: syn::Expr,
     pub id: Option<syn::Expr>,
     pub classes: Vec<syn::Expr>,
-    pub attributes: Vec<Attribute>,
+    pub attributes: ElemAttributes,
     pub children: Vec<Node>,
     pub close: bool,
 }
@@ -77,3 +77,10 @@ pub struct Attribute {
     pub name: syn::Expr,
     pub value: syn::Expr,
 }
+
+#[derive(Debug)]
+pub enum ElemAttributes {
+    Attributes(Vec<Attribute>),
+    RawAttributes(Vec<Node>),
+}
+


### PR DESCRIPTION
This is a pull request that would resolve my issue #26 this still requires some amount of `markup::raw` but this helps my use case definitely. Optimally the html escaping would be turned off by default in the attributes but it is not that important.

Hope this helps, have a nice day :)