### PR TITLE
Procedural Macro - Add placeholder lifetime for `std::fmt::Formatter`

### DIFF
--- a/markup-proc-macro/src/generate.rs
+++ b/markup-proc-macro/src/generate.rs
@@ -67,7 +67,7 @@ impl ToTokens for Struct {
             }
             impl #impl_generics std::fmt::Display for #name #ty_generics #where_clause {
                 #[inline]
-                fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+                fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     ::markup::Render::render(self, fmt)
                 }
             }

--- a/markup-proc-macro/src/generate.rs
+++ b/markup-proc-macro/src/generate.rs
@@ -150,7 +150,7 @@ impl Generate for Element {
 
         fn attr(stream: &mut Stream, name: &syn::Expr, expr: &syn::Expr, writer: &Ident) {
             let span = expr.span();
-            let value = syn::Ident::new("__value", span);
+            let value = Ident::new("__value", span);
             stream.extend(quote_spanned!(span => let #value = #expr;), writer);
             stream.extend(
                 quote_spanned! {


### PR DESCRIPTION
To resolve #36 the placeholder lifetime for `std::fmt::Formatter` has been added in `markup-proc-macro/src/generate.rs`.

This PR also removes a unnecessary path prefix (`syn`) in the `attr` function, which is also located in `markup-proc-macro/src/generate.rs`.